### PR TITLE
add link to our repo to the docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: FlexiHPC
+repo_url: https://github.com/nesi/flexi-docs
 theme:
   name: material
   logo: assets/images/nesi-logo.png


### PR DESCRIPTION
Using the repo_url setting to add a link to our repo to the docs site. this allows others to contribute improvements to our docs. https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/